### PR TITLE
Add the -t option to copy rootvg filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* Add mkwpar option ' -t' which copies root file systems from global WPAR
+
 ## 0.1.0 / Unreleased
 
 * Initial release

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please read the [Driver usage][driver_usage] page for more details.
 * **wpar_vg**	      Volume group to use to store shared wpar filesystems. Default to **rootvg**.
 * **wpar_rootvg**	  Specify the `hdisk` to use to create a rootvg system wpar.
 * **wpar_mksysb**	  uses a wpar backup. Specify a path to a backup to save time.
+* **wpar_copy_rootvg**	  adds the option ' -t' to copy rootvg file systems.
 * **isVersioned**         create a versioned wpar. Used only with **wpar_mksysb**.
 * **isWritable**	  adds the option ' -l' to have a non-shared, writable /usr file system and /opt file system. 
 

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -38,6 +38,7 @@ module Kitchen
       default_config :rmwpar, '/usr/sbin/rmwpar'
       default_config :lswpar, '/usr/sbin/lswpar'
       default_config :wpar_name, 'kitchenwpar'
+      default_config :wpar_copy_rootvg, false
       default_config :aix_host, 'localhost'
       default_config :aix_user, 'root'
       default_config :isWritable, false
@@ -86,6 +87,10 @@ module Kitchen
             cmd += " -C"
           end
           cmd += " -B #{config[:wpar_mksysb]}"
+        end
+
+        if config[:wpar_copy_rootvg]
+          cmd += ' -t'
         end
 
         if config[:isWritable]

--- a/test/wpar_spec.rb
+++ b/test/wpar_spec.rb
@@ -75,6 +75,13 @@ describe Kitchen::Driver::Wpar do
       expect(driver.send(:build_mkwpar_command)).to eq(default_string)
     end
 
+    it 'sets wpar_copy_rootvg to true' do
+      config[:wpar_copy_rootvg] = true
+      default_string = '/usr/sbin/mkwpar -s -n kitchenwpar -t'
+
+      expect(driver.send(:build_mkwpar_command)).to eq(default_string)
+    end
+
     it 'sets isWritable to false' do
       config[:isWritable] = false
       default_string = '/usr/sbin/mkwpar -s -n kitchenwpar'


### PR DESCRIPTION
From the `mkwpar` help page:

    -t = Copy rootvg file systems.