### PR TITLE
Adds support for starting sshd in the WPAR.

### DIFF
--- a/lib/kitchen/driver/wpar_version.rb
+++ b/lib/kitchen/driver/wpar_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Wpar Kitchen driver
-    WPAR_VERSION = "0.2.0"
+    WPAR_VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
- I've seen cases where sshd isn't started and kitchen is unable to converge because it can't ssh into the WPAR.
- This code updates the #create method to test for the sshd service, if it's running, and whether PAM support is configured.
- It takes the appropriate action to address the above cases, as needed.
- Tested on AIX 7.1 and Chef 12.19.