### PR TITLE
Adds support for sharing name resolution services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please read the [Driver usage][driver_usage] page for more details.
 * **wpar_mksysb**	  uses a wpar backup. Specify a path to a backup to save time.
 * **isVersioned**         create a versioned wpar. Used only with **wpar_mksysb**.
 * **isWritable**	  adds the option ' -l' to have a non-shared, writable /usr file system and /opt file system. 
+* **share_network_resolution**	  adds the option ' -r' to share name resolution services (i.e. `/etc/resolv.conf`) with the wpar.
 
 
 ### <a name="config-require-chef-omnibus"></a> require\_chef\_omnibus

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -42,6 +42,7 @@ module Kitchen
       default_config :aix_user, 'root'
       default_config :isWritable, false
       default_config :isVersioned, false
+      default_config :share_network_resolution, true
       default_config :echo, '/bin/echo'
       default_config :clogin, '/usr/sbin/clogin'
       default_config :lssrc, '/usr/bin/lssrc'
@@ -86,6 +87,10 @@ module Kitchen
         cmd = "#{config[:mkwpar]} -s -n #{config[:wpar_name]}"
         unless config[:wpar_address].nil?
           cmd += " -N address=#{config[:wpar_address]}"
+        end
+
+        if config[:share_network_resolution]
+          cmd += " -r"
         end
 
         unless config[:wpar_vg].nil?

--- a/lib/kitchen/driver/wpar_version.rb
+++ b/lib/kitchen/driver/wpar_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Wpar Kitchen driver
-    WPAR_VERSION = "0.3.0"
+    WPAR_VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
- Without this, WPARs are created not knowing how to resolve hosts.
- `-r` will copy files like `/etc/hosts` and `/etc/resolv.conf` from the global context into the WPAR.