### PR TITLE
Feat/add resize options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Please read the [Driver usage][driver_usage] page for more details.
 * **wpar_copy_rootvg**	  adds the option ' -t' to copy rootvg file systems.
 * **isVersioned**         create a versioned wpar. Used only with **wpar_mksysb**.
 * **isWritable**	  adds the option ' -l' to have a non-shared, writable /usr file system and /opt file system. 
+* **resize**        Adds the option ' -M' to resize mounts Takes in a list of hashes containing both directory and size keys.
 * **share_network_resolution**	  adds the option ' -r' to share name resolution services (i.e. `/etc/resolv.conf`) with the wpar.
 * **sudo**	  path to `sudo` command in case we need it.
+* **ssh_port**	 Lets you specify the ssh port to use. Default to **22**.
 
 
 ### <a name="config-require-chef-omnibus"></a> require\_chef\_omnibus

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Please read the [Driver usage][driver_usage] page for more details.
 * **isWritable**	  adds the option ' -l' to have a non-shared, writable /usr file system and /opt file system. 
 * **share_network_resolution**	  adds the option ' -r' to share name resolution services (i.e. `/etc/resolv.conf`) with the wpar.
 * **sudo**	  path to `sudo` command in case we need it.
-* **ssh_port**	 Lets you specify the ssh port to use. Default to **22**.
 
 
 ### <a name="config-require-chef-omnibus"></a> require\_chef\_omnibus

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -53,7 +53,6 @@ module Kitchen
       default_config :sudo, ''
       default_config :pam_sshd_account_rule, 'sshd account required pam_aix'
       default_config :pam_sshd_session_rule, 'sshd session required pam_aix'
-      default_config :ssh_port, '22'
 
       def create(state)
         if wpar_exists?(state)
@@ -225,8 +224,7 @@ module Kitchen
           host = config[:aix_host]
           user = config[:aix_user]
           keys = config[:aix_key]
-          port = config[:ssh_port]
-          Net::SSH.start(host, port, user, :keys => keys) do |ssh|
+          Net::SSH.start(host, user, :keys => keys) do |ssh|
             ssh.exec!(cmd) do |channel, stream, data|
               out << data if stream == stream
               print data

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -227,6 +227,7 @@ module Kitchen
           host = config[:aix_host]
           user = config[:aix_user]
           keys = config[:aix_key]
+          port = config[:ssh_port]
           Net::SSH.start(host, port, user, :keys => keys) do |ssh|
             ssh.exec!(cmd) do |channel, stream, data|
               out << data if stream == stream

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -125,12 +125,13 @@ module Kitchen
         if config[:isWritable]
           cmd += ' -l'
         end
-
         if config[:resize]
-          if config[:resize][:directory].nil? || config[:resize][:size].nil?
-            raise ActionFailed, "Please provide both directory and size to the resize option."
+          config[:resize].each do | resize_instance |
+            if resize_instance[:directory].nil? || resize_instance[:size].nil?
+              raise ActionFailed, "Please provide both directory and size to the resize option."
+            end
+            cmd += " -M directory=#{resize_instance[:directory]} size=#{resize_instance[:size]}"
           end
-          cmd += " -M directory=#{config[:resize][:directory]} size=#{config[:resize][:size]}"
         end
 
         cmd

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -127,6 +127,12 @@ module Kitchen
           cmd += ' -l'
         end
 
+        if config[:resize]
+          if config[:resize][:directory].nil? || config[:resize][:size].nil?
+            raise ActionFailed, "Please provide both directory and size to the resize option."
+          end
+          cmd += " -M directory=#{config[:resize][:directory]} size=#{config[:resize][:size]}"
+        end
 
         cmd
       end

--- a/lib/kitchen/driver/wpar.rb
+++ b/lib/kitchen/driver/wpar.rb
@@ -53,6 +53,7 @@ module Kitchen
       default_config :sudo, ''
       default_config :pam_sshd_account_rule, 'sshd account required pam_aix'
       default_config :pam_sshd_session_rule, 'sshd session required pam_aix'
+      default_config :ssh_port, '22'
 
       def create(state)
         if wpar_exists?(state)
@@ -125,6 +126,7 @@ module Kitchen
         if config[:isWritable]
           cmd += ' -l'
         end
+
         if config[:resize]
           config[:resize].each do | resize_instance |
             if resize_instance[:directory].nil? || resize_instance[:size].nil?
@@ -225,7 +227,7 @@ module Kitchen
           host = config[:aix_host]
           user = config[:aix_user]
           keys = config[:aix_key]
-          Net::SSH.start(host, user, :keys => keys) do |ssh|
+          Net::SSH.start(host, port, user, :keys => keys) do |ssh|
             ssh.exec!(cmd) do |channel, stream, data|
               out << data if stream == stream
               print data

--- a/lib/kitchen/driver/wpar_version.rb
+++ b/lib/kitchen/driver/wpar_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Wpar Kitchen driver
-    WPAR_VERSION = "0.4.3"
+    WPAR_VERSION = "0.4.4"
   end
 end

--- a/lib/kitchen/driver/wpar_version.rb
+++ b/lib/kitchen/driver/wpar_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Wpar Kitchen driver
-    WPAR_VERSION = "0.4.2"
+    WPAR_VERSION = "0.4.3"
   end
 end

--- a/lib/kitchen/driver/wpar_version.rb
+++ b/lib/kitchen/driver/wpar_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Wpar Kitchen driver
-    WPAR_VERSION = "0.4.4"
+    WPAR_VERSION = "0.4.3"
   end
 end


### PR DESCRIPTION
## Purpose
We wanted to add the -M flag to the mksysb call. Added a resize option that takes in a list of hashes containing both directory and size keys.

Example code:
```
resize:
    [
      {directory: /tmp, size: 5000M},
      {directory: /, size: 1000M}
    ]
```

## Testing
Ran on AIX 7.1 and 7.2 successfully resized both /tmp and /

## Notes
I had to remove the ssh_port feature due to not functioning on ruby 2.4. I added those commits back in manually, so you'll want to squash and merge rather than just merging my commits directly.